### PR TITLE
Get total VRAM size via Vulkan API for checking ResizableBAR

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1138,11 +1138,9 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, cha
 			MSG_DEBUG("Vulkan device %lu: device matches with pci_dev", i);
 
 		vkGetPhysicalDeviceMemoryProperties2(devices[i], &heap_info);
-		for (j = 0; j < heap_info.memoryProperties.memoryHeapCount; j++) {
-			if (VK_MEMORY_HEAP_DEVICE_LOCAL_BIT == heap_info.memoryProperties.memoryHeaps[j].flags) {
+		for (j = 0; j < heap_info.memoryProperties.memoryHeapCount; j++)
+			if (VK_MEMORY_HEAP_DEVICE_LOCAL_BIT == heap_info.memoryProperties.memoryHeaps[j].flags)
 				*total_vram_size = heap_info.memoryProperties.memoryHeaps[j].size;
-			}
-		}
 
 # ifdef VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME
 		VkDevice vk_dev_rt = {0};
@@ -1453,9 +1451,8 @@ static int find_devices(Labels *data)
 			get_vulkan_api_version(dev, vk_ver, vk_rt, &total_vram_size);
 			get_gpu_comp_unit(dev, &comp_unit, comp_unit_type, cl_ver);
 
-			if (0 < total_vram_size) {
-			   data->g_data->total_vram_size[data->gpu_count] = total_vram_size;
-			}
+			if (0 < total_vram_size)
+				data->g_data->total_vram_size[data->gpu_count] = total_vram_size;
 
 			casprintf(&data->tab_graphics[VALUE][GPU1VENDOR + data->gpu_count * GPUFIELDS], false, "%s", gpu_vendor);
 			casprintf(&data->tab_graphics[VALUE][GPU1DRIVER + data->gpu_count * GPUFIELDS], false, "%s", gpu_driver);
@@ -1758,11 +1755,14 @@ static int gpu_monitoring(Labels *data)
 			casprintf(&data->tab_graphics[VALUE][GPU1CORECLOCK   + i * GPUFIELDS], true, "%.0Lf MHz", strtoull(gclk, NULL, 10) / divisor_gclk);
 		if(!ret_mclk)
 			casprintf(&data->tab_graphics[VALUE][GPU1MEMCLOCK    + i * GPUFIELDS], true, "%.0Lf MHz", strtoull(mclk, NULL, 10) / divisor_mclk);
-		if(!ret_vram_used && !ret_vram_total) {
+		if(!ret_vram_used && !ret_vram_total)
+		{
 			casprintf(&data->tab_graphics[VALUE][GPU1MEMUSED     + i * GPUFIELDS], true, "%.0Lf %s / %.0Lf %s",
 				strtoull(vram_used,  NULL, 10) / divisor_vram, UNIT_MIB,
 				strtoull(vram_total, NULL, 10) / divisor_vram, UNIT_MIB);
-		} else if(strlen(data->tab_graphics[VALUE][GPU1MEMUSED + i * GPUFIELDS]) == 0 && 0 < data->g_data->total_vram_size[i]) {
+		}
+		else if(strlen(data->tab_graphics[VALUE][GPU1MEMUSED + i * GPUFIELDS]) == 0 && 0 < data->g_data->total_vram_size[i])
+		{
 			casprintf(&data->tab_graphics[VALUE][GPU1MEMUSED     + i * GPUFIELDS], false, "_ / %lu %s",
 				(data->g_data->total_vram_size[i] / (1 << 20)), UNIT_MIB);
 			casprintf(&data->tab_graphics[VALUE][GPU1REBAR       + i * GPUFIELDS], false,

--- a/src/core.c
+++ b/src/core.c
@@ -1171,6 +1171,7 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, cha
 	UNUSED(dev);
 	UNUSED(vulkan_version);
 	UNUSED(vulkan_rt);
+	UNUSED(total_vram_size);
 #endif /* HAS_Vulkan */
 
 	return err;

--- a/src/cpu-x.h
+++ b/src/cpu-x.h
@@ -279,8 +279,6 @@ typedef struct
 {
 	enum EnGpuDrv gpu_driver[LASTGRAPHICS / GPUFIELDS];
 	char      *device_path[LASTGRAPHICS / GPUFIELDS];
-	uint64_t  bar_size[LASTGRAPHICS / GPUFIELDS];
-	uint64_t  total_vram_size[LASTGRAPHICS / GPUFIELDS];
 } GraphicsData;
 
 typedef struct

--- a/src/cpu-x.h
+++ b/src/cpu-x.h
@@ -280,6 +280,7 @@ typedef struct
 	enum EnGpuDrv gpu_driver[LASTGRAPHICS / GPUFIELDS];
 	char      *device_path[LASTGRAPHICS / GPUFIELDS];
 	uint64_t  bar_size[LASTGRAPHICS / GPUFIELDS];
+	uint64_t  total_vram_size[LASTGRAPHICS / GPUFIELDS];
 } GraphicsData;
 
 typedef struct

--- a/src/main.c
+++ b/src/main.c
@@ -793,9 +793,7 @@ int main(int argc, char *argv[])
 	data->g_data = &(GraphicsData)
 	{
 		.gpu_driver  = { GPUDRV_UNKNOWN },
-		.device_path = { NULL },
-		.bar_size    = { 0 },
-		.total_vram_size = { 0 }
+		.device_path = { NULL }
 	};
 	data->b_data = &(BenchData)
 	{

--- a/src/main.c
+++ b/src/main.c
@@ -794,7 +794,8 @@ int main(int argc, char *argv[])
 	{
 		.gpu_driver  = { GPUDRV_UNKNOWN },
 		.device_path = { NULL },
-		.bar_size    = { 0 }
+		.bar_size    = { 0 },
+		.total_vram_size = { 0 }
 	};
 	data->b_data = &(BenchData)
 	{


### PR DESCRIPTION
This PR get total VRAM size via Vulkan API for checking ResizableBAR and check ResizableBAR in `find_device` function.

Resolve #273 