### PR TITLE
`libfuse2` no longer needed

### DIFF
--- a/.github/workflows/appimage_versioned.yml
+++ b/.github/workflows/appimage_versioned.yml
@@ -88,8 +88,8 @@ jobs:
 
           ## Binary
 
-          - **AppImage (ARM64)**: CPU-X-${{ env.VERSION }}-aarch64.AppImage (**libfuse2** package is required)
-          - **AppImage (x86_64)**: CPU-X-${{ env.VERSION }}-x86_64.AppImage (**libfuse2** package is required)
+          - **AppImage (ARM64)**: CPU-X-${{ env.VERSION }}-aarch64.AppImage
+          - **AppImage (x86_64)**: CPU-X-${{ env.VERSION }}-x86_64.AppImage
 
           *Note: a Polkit Authentication agent is mandatory to start daemon from GUI.*
 


### PR DESCRIPTION
linuxdeploy now defaults to using the static appimage runtime, so libfuse2 is no longer a dependency. 

![image](https://github.com/user-attachments/assets/b2102fea-f48b-4ed2-8227-f5bab5c8c400)

It also uses zstd comp which makes the appimage slightly smaller. 