### PR TITLE
Run OpenGL/Vulkan/OpenCL in a child process

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,11 +9,12 @@ task:
 
   install_script:
     - pkg update -f
-    - pkg install -y bash cmake ninja pkgconf gettext nasm gtkmm30 ncurses pciutils libglvnd opencl ocl-icd vulkan-loader vulkan-headers libstatgrab
+    - pkg install -y bash cmake ninja pkgconf gettext nasm gtkmm30 ncurses pciutils libglvnd opencl ocl-icd pocl vulkan-loader vulkan-headers libstatgrab
+    - sed -i .orig "/Requires: OpenCL-Headers/d" /usr/local/libdata/pkgconfig/OpenCL.pc # workaround for OpenCL headers
 
   build_script:
     - bash -x ./scripts/build_libcpuid.sh "Debug"
-    - cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr -DWITH_OPENCL=1
+    - cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr
     - cmake --build build
     - cmake --install build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ option(WITH_LIBCPUID      "Use Libcpuid library"                                
 option(WITH_LIBPCI        "Use Libpci library"                                                ON)
 option(WITH_LIBEGL        "Use Libegl library"                                                ON)
 option(WITH_VULKAN        "Use Vulkan library"                                                ON)
-option(WITH_OPENCL        "Use OpenCL library"                                                OFF) # Disabled due to issues (#238, #258, #264)
+option(WITH_OPENCL        "Use OpenCL library"                                                ON)
 option(WITH_LIBPROCPS     "Use Libprocps library"                                             ON)
 option(WITH_LIBSTATGRAB   "Use Libstatgrab library"                                           ON)
 option(WITH_DMIDECODE     "Built-in Dmidecode"                                                ON)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ These dependencies are needed to **build²** and **run** CPU-X:
 * [Pciutils](https://mj.ucw.cz/sw/pciutils/)  
 * [EGL](https://www.khronos.org/egl/) (version 1.5 or newer is needed), with [OpenGL](https://www.opengl.org/)  
 * [Vulkan](https://www.vulkan.org/)  
-* [OpenCL](https://www.khronos.org/opencl/) (version 1.2 or newer is needed), **disabled by default** (enable with `-DWITH_OPENCL=1` during CMake invocation)  
+* [OpenCL](https://www.khronos.org/opencl/) (version 1.2 or newer is needed)  
 * [Procps-ng](https://sourceforge.net/projects/procps-ng/) (Linux) / [Libstatgrab](https://www.i-scream.org/libstatgrab/) (*BSD)  
 
 **²**On some GNU/Linux distributions, the appropriate **-dev** or **-devel** package is needed.

--- a/scripts/build_cpu_x.sh
+++ b/scripts/build_cpu_x.sh
@@ -22,7 +22,7 @@ if [[ $# -ge 3 ]]; then
 else
 	# Standard build
 	DST_DIR=""
-	CMAKE_EXTRA_OPTIONS="-DWITH_OPENCL=1"
+	CMAKE_EXTRA_OPTIONS=""
 fi
 
 case "$VERSION_ID" in

--- a/src/core/internal.hpp
+++ b/src/core/internal.hpp
@@ -27,7 +27,6 @@
 #include "data.hpp"
 
 using GpuDrv = Data::Graphics::Card::GpuDrv;
-extern bool __sigabrt_received;
 
 
 /***************************** Bandwidth *****************************/

--- a/src/core/internal.hpp
+++ b/src/core/internal.hpp
@@ -78,7 +78,7 @@ int set_gpu_compute_unit(Data::Graphics::Card &card, struct pci_dev *dev);
 /***************************** Libopengl *****************************/
 
 /* Set the OpenGL version for GPU */
-int set_gpu_opengl_version(Data::Graphics::Card &card);
+int set_gpu_opengl_version(std::string card_vendor, int pfd_out);
 
 
 /***************************** Libpci *****************************/

--- a/src/core/internal.hpp
+++ b/src/core/internal.hpp
@@ -99,7 +99,7 @@ int system_dynamic(Data &data);
 /***************************** Libvulkan *****************************/
 
 /* Set the Vulkan version for GPU */
-int set_gpu_vulkan_version(Data::Graphics::Card &card, struct pci_dev *dev);
+int set_gpu_vulkan_version(std::string card_vendor, struct pci_dev *dev, int pfd_out);
 
 
 #endif /* _CORE_INTERNAL_HPP_ */

--- a/src/core/internal.hpp
+++ b/src/core/internal.hpp
@@ -71,8 +71,8 @@ int cputab_package_fallback(Data &data);
 
 /***************************** Libopencl *****************************/
 
-/* Set number of Compute Unit (CU) / Workgroup Processor (WGP) / Execution Unit (EU) / Streaming Multiprocessor (SM) for a GPU */
-int set_gpu_compute_unit(Data::Graphics::Card &card, struct pci_dev *dev);
+/* Set the OpenCL version and Compute Unit (CU) / Workgroup Processor (WGP) / Execution Unit (EU) / Streaming Multiprocessor (SM) for a GPU */
+int set_gpu_opencl_version(std::string card_vendor, struct pci_dev *pci_dev, int pfd_out);
 
 
 /***************************** Libopengl *****************************/

--- a/src/core/libopencl.cpp
+++ b/src/core/libopencl.cpp
@@ -36,217 +36,280 @@ extern "C" {
 }
 
 
-#define OPENCL_INFO_BUFFER_SIZE 1024
 #define CLINFO(dev_id, PARAM, prop) \
 	clGetDeviceInfo(dev_id, PARAM, sizeof(prop), &prop, NULL)
-/* Set number of Compute Unit (CU) / Workgroup Processor (WGP) / Execution Unit (EU) / Streaming Multiprocessor (SM) for a GPU */
-int set_gpu_compute_unit([[maybe_unused]] Data::Graphics::Card &card, [[maybe_unused]] struct pci_dev *dev)
+static bool opencl_get_vendor_amd(int pfd_out,
+	cl_uint platform_num,
+	cl_uint device_num, cl_device_id device_id,
+	char *device_name, char *device_version,
+	struct pci_dev *pci_dev)
 {
-	int ret_cl = 0;
+	cl_int ret_cl = 0;
+	uint32_t comp_unit = 0;
+	cl_uint amd_gfx_major = 0;
+	cl_device_topology_amd topo_amd;
+	MSG_DEBUG("OpenCL platform %u, device %u: vendor is AMD", platform_num, device_num);
 
+	ret_cl = CLINFO(device_id, CL_DEVICE_TOPOLOGY_AMD, topo_amd);
+	if(ret_cl != CL_SUCCESS)
+	{
+		MSG_WARNING(_("OpenCL driver for '%s %s' does not support CL_DEVICE_TOPOLOGY_AMD (%s)"), device_name, device_version, opencl_error(ret_cl));
+		return false;
+	}
+
+	if((pci_dev->bus  !=  topo_amd.pcie.bus)     ||
+	   (pci_dev->dev  !=  topo_amd.pcie.device)  ||
+	   (pci_dev->func !=  topo_amd.pcie.function))
+	{
+		MSG_DEBUG("PCI device %02x:%02x.%d is not matching OpenCL device %02x:%02x.%d", pci_dev->bus, pci_dev->dev, pci_dev->func, topo_amd.pcie.bus, topo_amd.pcie.device, topo_amd.pcie.function);
+		return false;
+	}
+
+	ret_cl = CLINFO(device_id, CL_DEVICE_GFXIP_MAJOR_AMD, amd_gfx_major);
+	if(ret_cl != CL_SUCCESS)
+	{
+		MSG_WARNING(_("OpenCL driver for '%s %s' does not support CL_DEVICE_GFXIP_MAJOR_AMD (%s)"), device_name, device_version, opencl_error(ret_cl));
+		amd_gfx_major = 0;
+	}
+	MSG_DEBUG("OpenCL platform %u, device %u: CL_DEVICE_GFXIP_MAJOR_AMD is %u", platform_num, device_num, amd_gfx_major);
+
+	ret_cl = CLINFO(device_id, CL_DEVICE_MAX_COMPUTE_UNITS, comp_unit);
+	if(ret_cl != CL_SUCCESS)
+	{
+		MSG_ERROR(_("OpenCL driver for '%s %s' does not support CL_DEVICE_MAX_COMPUTE_UNITS (%s)"), device_name, device_version, opencl_error(ret_cl));
+		return false;
+	}
+
+	/* Set unit type:
+		- Compute Unit (CU): GCN
+		- Workgroup Processor (WGP): RDNA, i.e. GFX10+
+	*/
+	const std::string comp_unit_type = (amd_gfx_major < 10) ? "CU" : "WGP";
+	const std::string comp_unit_str  = std::to_string(comp_unit) + " " + comp_unit_type;
+	MSG_DEBUG("OpenCL platform %u, device %u: found %s", platform_num, device_num, comp_unit_str.c_str());
+	write_string_to_pipe(comp_unit_str, pfd_out);
+
+	return true;
+}
+
+static bool opencl_get_vendor_intel(int pfd_out,
+	cl_uint platform_num,
+	cl_uint device_num, cl_device_id device_id,
+	char *device_name, char *device_version)
+{
+	cl_int ret_cl = 0;
+	uint32_t comp_unit = 0;
+
+	MSG_DEBUG("OpenCL platform %u, device %u: vendor is Intel", platform_num, device_num);
+	ret_cl = CLINFO(device_id, CL_DEVICE_MAX_COMPUTE_UNITS, comp_unit);
+	if(ret_cl != CL_SUCCESS)
+	{
+		MSG_ERROR(_("OpenCL driver for '%s %s' does not support CL_DEVICE_MAX_COMPUTE_UNITS (%s)"), device_name, device_version, opencl_error(ret_cl));
+		return false;
+	}
+
+	const std::string comp_unit_str = std::to_string(comp_unit) + " EU"; // Execution Unit
+	MSG_DEBUG("OpenCL platform %u, device %u: found %s", platform_num, device_num, comp_unit_str.c_str());
+	write_string_to_pipe(comp_unit_str, pfd_out);
+
+	return true;
+}
+
+static bool opencl_get_vendor_nvidia(int pfd_out,
+	cl_uint platform_num,
+	cl_uint device_num, cl_device_id device_id,
+	char *device_name, char *device_version,
+	struct pci_dev *pci_dev)
+{
+	cl_int ret_cl = 0;
+	cl_uint ocl_domain_nv, ocl_bus_nv, ocl_dev_nv;
+	uint8_t ret_domain_nv = 0, ret_bus_nv = 0, ret_dev_nv = 0;
+	uint32_t comp_unit = 0;
+	MSG_DEBUG("OpenCL platform %u, device %u: vendor is NVIDIA", platform_num, device_num);
+
+	ret_domain_nv = CLINFO(device_id, CL_DEVICE_PCI_DOMAIN_ID_NV, ocl_domain_nv);
+	ret_bus_nv    = CLINFO(device_id, CL_DEVICE_PCI_BUS_ID_NV,    ocl_bus_nv);
+	ret_dev_nv    = CLINFO(device_id, CL_DEVICE_PCI_SLOT_ID_NV,   ocl_dev_nv); // Slot == Device
+
+	if((ret_domain_nv != CL_SUCCESS) || (ret_bus_nv != CL_SUCCESS) || (ret_dev_nv != CL_SUCCESS))
+	{
+		MSG_WARNING(_("OpenCL driver for '%s %s' does not support CL_DEVICE_PCI_DOMAIN_ID_NV (%s), CL_DEVICE_PCI_BUS_ID_NV (%s) or CL_DEVICE_PCI_SLOT_ID_NV (%s)"),
+					device_name, device_version, opencl_error(ret_domain_nv), opencl_error(ret_bus_nv), opencl_error(ret_dev_nv));
+		return false;
+	}
+
+	if((pci_dev->domain != static_cast<int>(ocl_domain_nv)) ||
+	   (pci_dev->bus    !=       ocl_bus_nv)                ||
+	   (pci_dev->dev    !=       ocl_dev_nv))
+	{
+		MSG_DEBUG("PCI device %04x:%02x:%02x is not matching OpenCL device %04x:%02x:%02x", pci_dev->domain, pci_dev->bus, pci_dev->dev, ocl_domain_nv, ocl_bus_nv, ocl_dev_nv);
+		return false;
+	}
+
+	ret_cl = CLINFO(device_id, CL_DEVICE_MAX_COMPUTE_UNITS, comp_unit);
+	if(ret_cl != CL_SUCCESS)
+	{
+		MSG_ERROR(_("OpenCL driver for '%s %s' does not support CL_DEVICE_MAX_COMPUTE_UNITS (%s)"), device_name, device_version, opencl_error(ret_cl));
+		return false;
+	}
+
+	const std::string comp_unit_str = std::to_string(comp_unit) + " SM"; // Streaming Multiprocessor
+	MSG_DEBUG("OpenCL platform %u, device %u: found %s", platform_num, device_num, comp_unit_str.c_str());
+	write_string_to_pipe(comp_unit_str, pfd_out);
+
+	return true;
+}
+
+/* Get compute units depending on vendor */
+static bool opencl_get_vendor(int pfd_out,
+	cl_uint platform_num,
+	cl_uint device_num, cl_device_id device_id,
+	cl_uint ocl_vendor, char *device_name, char *device_version,
+	struct pci_dev *pci_dev)
+{
+	switch(ocl_vendor)
+	{
+		case DEV_VENDOR_ID_AMD:    return opencl_get_vendor_amd   (pfd_out, platform_num, device_num, device_id, device_name, device_version, pci_dev);
+		case DEV_VENDOR_ID_INTEL:  return opencl_get_vendor_intel (pfd_out, platform_num, device_num, device_id, device_name, device_version);
+		case DEV_VENDOR_ID_NVIDIA: return opencl_get_vendor_nvidia(pfd_out, platform_num, device_num, device_id, device_name, device_version, pci_dev);
+		default: MSG_WARNING(_("OpenCL is not supported with your GPU vendor (0x%X)"), ocl_vendor);
+	}
+
+	return false;
+}
+
+#define OPENCL_INFO_BUFFER_SIZE 1024
+static bool opencl_get_device(int pfd_out,
+	cl_uint platform_num,
+	cl_uint device_num, cl_device_id device_id,
+	struct pci_dev *pci_dev)
+{
+	cl_int ret_cl = 0;
+	cl_uint ocl_vendor;
+	std::string comp_unit_type;
+	char device_name[OPENCL_INFO_BUFFER_SIZE] = "", device_version[OPENCL_INFO_BUFFER_SIZE] = "";
+	MSG_DEBUG("Looping into OpenCL platform %u, device %u", platform_num, device_num);
+
+	CLINFO(device_id, CL_DEVICE_VENDOR_ID, ocl_vendor);
+	if(pci_dev->vendor_id != ocl_vendor)
+		return false;
+	MSG_DEBUG("OpenCL platform %u, device %u: found vendor 0x%X", platform_num, device_num, ocl_vendor);
+
+	ret_cl = clGetDeviceInfo(device_id, CL_DEVICE_NAME, sizeof(device_name), device_name, NULL);
+	if(ret_cl != CL_SUCCESS)
+	{
+		MSG_ERROR(_("failed to get name for device %u (%s)"), device_num, opencl_error(ret_cl));
+		return false;
+	}
+	MSG_DEBUG("OpenCL platform %u, device %u: name is '%s'", platform_num, device_num, device_name);
+
+	ret_cl = clGetDeviceInfo(device_id, CL_DEVICE_VERSION, sizeof(device_version), device_version, NULL);
+	if(ret_cl != CL_SUCCESS)
+	{
+		MSG_ERROR(_("failed to get version for device %u (%s)"), device_num, opencl_error(ret_cl));
+		return false;
+	}
+	MSG_DEBUG("OpenCL platform %u, device %u: version is '%s'", platform_num, device_num, device_version);
+
+	/* Set OpenCL version */
+	std::string opencl_version = device_version;
+	const size_t cl_index = opencl_version.find("OpenCL");
+	if(cl_index != std::string::npos)
+		opencl_version.erase(cl_index, 6 + 1); // 6 = "OpenCL" string
+	const size_t mesa_index = opencl_version.find("Mesa");
+	if(mesa_index != std::string::npos)
+		opencl_version.erase(mesa_index, std::string::npos);
+	write_string_to_pipe(opencl_version, pfd_out);
+
+	return opencl_get_vendor(pfd_out, platform_num, device_num, device_id, ocl_vendor, device_name, device_version, pci_dev);
+}
+#undef CLINFO
+
+static bool opencl_get_platform(int pfd_out,
+	cl_uint platform_num, cl_platform_id platform_id,
+	struct pci_dev *pci_dev)
+{
 	bool gpu_found = false;
+	cl_int ret_cl = 0;
+	cl_uint num_devices = 0;
 	char platform_name[OPENCL_INFO_BUFFER_SIZE] = "", platform_version[OPENCL_INFO_BUFFER_SIZE] = "";
-	cl_uint num_pf = 0;
+	MSG_DEBUG("Looping into OpenCL platform %u", platform_num);
+
+	ret_cl = clGetPlatformInfo(platform_id, CL_PLATFORM_NAME, sizeof(platform_name), platform_name, NULL); // get platform name
+	if(ret_cl != CL_SUCCESS)
+	{
+		MSG_ERROR(_("failed to get name for platform %u (%s)"), platform_num, opencl_error(ret_cl));
+		return false;
+	}
+	MSG_DEBUG("OpenCL platform %u: name is '%s'", platform_num, platform_name);
+
+	ret_cl = clGetPlatformInfo(platform_id, CL_PLATFORM_VERSION, sizeof(platform_version), platform_version, NULL); // get platform version
+	if(ret_cl != CL_SUCCESS)
+	{
+		MSG_ERROR(_("failed to get version for platform %u (%s)"), platform_num, opencl_error(ret_cl));
+		return false;
+	}
+	MSG_DEBUG("OpenCL platform %u: version is '%s'", platform_num, platform_version);
+
+	ret_cl = clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_ALL, 0, NULL, &num_devices); // get number of device
+	if((ret_cl != CL_SUCCESS) || (num_devices == 0))
+	{
+		MSG_ERROR(_("failed to find number of OpenCL devices for platform '%s %s' (%s)"), platform_name, platform_version, (num_devices == 0) ? _("0 device") : opencl_error(ret_cl));
+		return false;
+	}
+	MSG_DEBUG("OpenCL platform %u: found %u devices", platform_num, num_devices);
+
+	std::vector<cl_device_id> devices(num_devices);
+	ret_cl = clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_ALL, num_devices, devices.data(), NULL); // get all devices
+	if(ret_cl != CL_SUCCESS)
+	{
+		MSG_ERROR(_("failed to get all of OpenCL devices for platform '%s %s' (%s)"), platform_name, platform_version, opencl_error(ret_cl));
+		return false;
+	}
+
+	for(cl_uint device_num = 0; (device_num < num_devices) && !gpu_found; device_num++)
+		gpu_found = opencl_get_device(pfd_out, platform_num, device_num, devices[device_num], pci_dev);
+
+	return gpu_found;
+}
+
+/* Set the OpenCL version and Compute Unit (CU) / Workgroup Processor (WGP) / Execution Unit (EU) / Streaming Multiprocessor (SM) for a GPU */
+int set_gpu_opencl_version(std::string card_vendor, struct pci_dev *pci_dev, int pfd_out)
+{
+	bool gpu_found = false;
+	cl_int ret_cl = 0;
+	cl_uint num_platforms = 0;
 
 	MSG_VERBOSE("%s", _("Finding OpenCL API version"));
-	ret_cl = clGetPlatformIDs(0, NULL, &num_pf); // get number of platform
-	if(__sigabrt_received || (ret_cl != CL_SUCCESS) || (num_pf == 0))
+	ret_cl = clGetPlatformIDs(0, NULL, &num_platforms); // get number of platform
+	if((ret_cl != CL_SUCCESS) || (num_platforms == 0))
 	{
-		MSG_WARNING(_("There is no platform with OpenCL support (%s)"), __sigabrt_received ? "SIGABRT" : opencl_error(ret_cl));
-		__sigabrt_received = false;
+		MSG_WARNING(_("There is no platform with OpenCL support (%s)"), opencl_error(ret_cl));
 		return ret_cl;
 	}
-	MSG_DEBUG("Number of OpenCL platforms: %u", num_pf);
+	MSG_DEBUG("Number of OpenCL platforms: %u", num_platforms);
 
-	std::vector<cl_platform_id> platforms(num_pf);
-	ret_cl = clGetPlatformIDs(num_pf, platforms.data(), NULL); // get all platforms
-	if(__sigabrt_received || (ret_cl != CL_SUCCESS))
+	std::vector<cl_platform_id> platforms(num_platforms);
+	ret_cl = clGetPlatformIDs(num_platforms, platforms.data(), NULL); // get all platforms
+	if(ret_cl != CL_SUCCESS)
 	{
-		MSG_ERROR(_("failed to get all OpenCL platforms (%s)"), __sigabrt_received ? "SIGABRT" : opencl_error(ret_cl));
-		__sigabrt_received = false;
+		MSG_ERROR(_("failed to get all OpenCL platforms (%s)"), opencl_error(ret_cl));
 		return ret_cl;
 	}
 
-	for(cl_uint i = 0; (i < num_pf) && !gpu_found; i++) // find GPU devices
+	for(cl_uint platform_num = 0; (platform_num < num_platforms) && !gpu_found; platform_num++) // find GPU devices
+		gpu_found = opencl_get_platform(pfd_out, platform_num, platforms[platform_num], pci_dev);
+
+	if(!gpu_found)
 	{
-		cl_uint num_ocl_dev = 0;
-		MSG_DEBUG("Looping into OpenCL platform %u", i);
+		MSG_WARNING(_("Unable to find OpenCL driver for vendor %s"), card_vendor.c_str());
+		write_string_to_pipe(std::string(), pfd_out); // OpenCL version
+		write_string_to_pipe(std::string(), pfd_out); // Compute units
+	}
 
-		ret_cl = clGetPlatformInfo(platforms[i], CL_PLATFORM_NAME, sizeof(platform_name), platform_name, NULL); // get platform name
-		if(ret_cl != CL_SUCCESS)
-		{
-			MSG_ERROR(_("failed to get name for platform %u (%s)"), i, opencl_error(ret_cl));
-			continue;
-		}
-		MSG_DEBUG("OpenCL platform %u: name is '%s'", i, platform_name);
-
-		ret_cl = clGetPlatformInfo(platforms[i], CL_PLATFORM_VERSION, sizeof(platform_version), platform_version, NULL); // get platform version
-		if(ret_cl != CL_SUCCESS)
-		{
-			MSG_ERROR(_("failed to get version for platform %u (%s)"), i, opencl_error(ret_cl));
-			continue;
-		}
-		MSG_DEBUG("OpenCL platform %u: version is '%s'", i, platform_version);
-
-		ret_cl = clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_ALL, 0, NULL, &num_ocl_dev); // get number of device
-		if((ret_cl != CL_SUCCESS) || (num_ocl_dev == 0))
-		{
-			MSG_ERROR(_("failed to find number of OpenCL devices for platform '%s %s' (%s)"), platform_name, platform_version, (num_ocl_dev == 0) ? _("0 device") : opencl_error(ret_cl));
-			continue;
-		}
-		MSG_DEBUG("OpenCL platform %u: found %u devices", i, num_ocl_dev);
-
-		std::vector<cl_device_id> devices(num_ocl_dev);
-		ret_cl = clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_ALL, num_ocl_dev, devices.data(), NULL); // get all devices
-		if(ret_cl != CL_SUCCESS)
-		{
-			MSG_ERROR(_("failed to get all of OpenCL devices for platform '%s %s' (%s)"), platform_name, platform_version, opencl_error(ret_cl));
-			continue;
-		}
-
-		for(cl_uint j = 0; (j < num_ocl_dev) && !gpu_found; j++)
-		{
-			cl_uint ocl_vendor;
-			uint32_t comp_unit = 0;
-			std::string comp_unit_type;
-			char device_name[OPENCL_INFO_BUFFER_SIZE] = "", device_version[OPENCL_INFO_BUFFER_SIZE] = "";
-			MSG_DEBUG("Looping into OpenCL platform %u, device %u", i, j);
-
-			CLINFO(devices[j], CL_DEVICE_VENDOR_ID, ocl_vendor);
-			if(dev->vendor_id != ocl_vendor)
-				continue;
-			MSG_DEBUG("OpenCL platform %u, device %u: found vendor 0x%X", i, j, ocl_vendor);
-
-			ret_cl = clGetDeviceInfo(devices[j], CL_DEVICE_NAME, sizeof(device_name), device_name, NULL);
-			if(ret_cl != CL_SUCCESS)
-			{
-				MSG_ERROR(_("failed to get name for device %u (%s)"), j, opencl_error(ret_cl));
-				continue;
-			}
-			MSG_DEBUG("OpenCL platform %u, device %u: name is '%s'", i, j, device_name);
-
-			ret_cl = clGetDeviceInfo(devices[j], CL_DEVICE_VERSION, sizeof(device_version), device_version, NULL);
-			if(ret_cl != CL_SUCCESS)
-			{
-				MSG_ERROR(_("failed to get version for device %u (%s)"), j, opencl_error(ret_cl));
-				continue;
-			}
-			MSG_DEBUG("OpenCL platform %u, device %u: version is '%s'", i, j, device_version);
-
-			/* Set OpenCL version */
-			card.opencl_version.value = device_version;
-			const size_t cl_index = card.opencl_version.value.find("OpenCL");
-			if(cl_index != std::string::npos)
-				card.opencl_version.value.erase(cl_index, 6 + 1); // 6 = "OpenCL" string
-			const size_t mesa_index = card.opencl_version.value.find("Mesa");
-			if(mesa_index != std::string::npos)
-				card.opencl_version.value.erase(mesa_index, std::string::npos);
-
-			/* Get compute units depending on vendor */
-			switch (ocl_vendor)
-			{
-				case DEV_VENDOR_ID_AMD:
-				{
-					cl_uint amd_gfx_major = 0;
-					cl_device_topology_amd topo_amd;
-					MSG_DEBUG("OpenCL platform %u, device %u: vendor is AMD", i, j);
-
-					ret_cl = CLINFO(devices[j], CL_DEVICE_TOPOLOGY_AMD, topo_amd);
-					if(ret_cl != CL_SUCCESS)
-					{
-						MSG_WARNING(_("OpenCL driver for '%s %s' does not support CL_DEVICE_TOPOLOGY_AMD (%s)"), device_name, device_version, opencl_error(ret_cl));
-						continue;
-					}
-
-					if((dev->bus  ==  topo_amd.pcie.bus)     &&
-					   (dev->dev  ==  topo_amd.pcie.device)  &&
-					   (dev->func ==  topo_amd.pcie.function))
-					{
-						ret_cl = CLINFO(devices[j], CL_DEVICE_GFXIP_MAJOR_AMD, amd_gfx_major);
-						if(ret_cl != CL_SUCCESS)
-						{
-							MSG_WARNING(_("OpenCL driver for '%s %s' does not support CL_DEVICE_GFXIP_MAJOR_AMD (%s)"), device_name, device_version, opencl_error(ret_cl));
-							amd_gfx_major = 0;
-						}
-						MSG_DEBUG("OpenCL platform %u, device %u: CL_DEVICE_GFXIP_MAJOR_AMD is %u", i, j, amd_gfx_major);
-
-						ret_cl = CLINFO(devices[j], CL_DEVICE_MAX_COMPUTE_UNITS, comp_unit);
-						if(ret_cl != CL_SUCCESS)
-						{
-							MSG_ERROR(_("OpenCL driver for '%s %s' does not support CL_DEVICE_MAX_COMPUTE_UNITS (%s)"), device_name, device_version, opencl_error(ret_cl));
-							continue;
-						}
-						/* Set unit type:
-						   - Compute Unit (CU): GCN
-						   - Workgroup Processor (WGP): RDNA, i.e. GFX10+
-						*/
-						comp_unit_type = (amd_gfx_major < 10) ? "CU" : "WGP";
-						MSG_DEBUG("OpenCL platform %u, device %u: found %lu %s", i, j, comp_unit, comp_unit_type.c_str());
-						card.comp_unit.value = std::to_string(comp_unit) + " " + comp_unit_type;
-						gpu_found = true;
-					}
-					break;
-				}
-				case DEV_VENDOR_ID_INTEL:
-				{
-					MSG_DEBUG("OpenCL platform %u, device %u: vendor is Intel", i, j);
-					ret_cl = CLINFO(devices[j], CL_DEVICE_MAX_COMPUTE_UNITS, comp_unit);
-					if(ret_cl != CL_SUCCESS)
-					{
-						MSG_ERROR(_("OpenCL driver for '%s %s' does not support CL_DEVICE_MAX_COMPUTE_UNITS (%s)"), device_name, device_version, opencl_error(ret_cl));
-						continue;
-					}
-					comp_unit_type = "EU"; // Execution Unit
-					MSG_DEBUG("OpenCL platform %u, device %u: found %lu %s", i, j, comp_unit, comp_unit_type.c_str());
-					card.comp_unit.value = std::to_string(comp_unit) + " " + comp_unit_type;
-					gpu_found = true;
-					break;
-				}
-				case DEV_VENDOR_ID_NVIDIA:
-				{
-					cl_uint ocl_domain_nv, ocl_bus_nv, ocl_dev_nv;
-					uint8_t ret_domain_nv = 0, ret_bus_nv = 0, ret_dev_nv = 0;
-					MSG_DEBUG("OpenCL platform %u, device %u: vendor is NVIDIA", i, j);
-
-					ret_domain_nv = CLINFO(devices[j], CL_DEVICE_PCI_DOMAIN_ID_NV, ocl_domain_nv);
-					ret_bus_nv    = CLINFO(devices[j], CL_DEVICE_PCI_BUS_ID_NV,    ocl_bus_nv);
-					ret_dev_nv    = CLINFO(devices[j], CL_DEVICE_PCI_SLOT_ID_NV,   ocl_dev_nv); // Slot == Device
-
-					if((ret_domain_nv != CL_SUCCESS) || (ret_bus_nv != CL_SUCCESS) || (ret_dev_nv != CL_SUCCESS))
-					{
-						MSG_WARNING(_("OpenCL driver for '%s %s' does not support CL_DEVICE_PCI_DOMAIN_ID_NV (%s), CL_DEVICE_PCI_BUS_ID_NV (%s) or CL_DEVICE_PCI_SLOT_ID_NV (%s)"),
-						            device_name, device_version, opencl_error(ret_domain_nv), opencl_error(ret_bus_nv), opencl_error(ret_dev_nv));
-						continue;
-					}
-
-					if((dev->domain == static_cast<int>(ocl_domain_nv)) &&
-					   (dev->bus    ==       ocl_bus_nv)                &&
-					   (dev->dev    ==       ocl_dev_nv))
-					{
-						ret_cl = CLINFO(devices[j], CL_DEVICE_MAX_COMPUTE_UNITS, comp_unit);
-						if(ret_cl != CL_SUCCESS)
-						{
-							MSG_ERROR(_("OpenCL driver for '%s %s' does not support CL_DEVICE_MAX_COMPUTE_UNITS (%s)"), device_name, device_version, opencl_error(ret_cl));
-							continue;
-						}
-						comp_unit_type = "SM"; // Streaming Multiprocessor
-						MSG_DEBUG("OpenCL platform %u, device %u: found %lu %s", i, j, comp_unit, comp_unit_type.c_str());
-						card.comp_unit.value = std::to_string(comp_unit) + " " + comp_unit_type;
-						gpu_found = true;
-					}
-					break;
-				}
-				default:
-					MSG_WARNING(_("OpenCL is not supported with your GPU vendor (0x%X)"), ocl_vendor);
-					break;
-			} /* end switch (vendor_id) */
-		} /* end num_ocl_dev */
-	} /* end num_pf */
-
-	return ret_cl;
+	return (int) ret_cl;
 }
 #undef OPENCL_INFO_BUFFER_SIZE
-#undef CLINFO
 
 
 #endif /* HAS_LIBPCI */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,8 +45,6 @@
 
 #define LOG_FILE "/tmp/cpu-x.log"
 
-bool __sigabrt_received = false;
-
 
 /************************* Options-related functions *************************/
 
@@ -457,7 +455,6 @@ static void sighandler_fatal(int signum)
 /* Action on SIGABRT */
 static void sighandler_abrt(int signum)
 {
-	__sigabrt_received = true;
 	common_sighandler(signum, false);
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -233,6 +233,30 @@ std::string string_with_temperature_unit(const double temp_celsius)
 	return ret;
 }
 
+/* Write a string to a pipe */
+void write_string_to_pipe(std::string str, int pfd_out)
+{
+	std::string::size_type size = str.size();
+	write(pfd_out, &size, sizeof(size));
+	write(pfd_out, str.c_str(), str.size());
+}
+
+/* Read a string from a pipe */
+std::string read_string_from_pipe(int pfd_in)
+{
+	std::string::size_type size = 0;
+	ssize_t read_bytes;
+
+	read_bytes = read(pfd_in, &size, sizeof(size));
+	if((read_bytes <= 0) && (size <= 0))
+		return std::string();
+
+	std::string str(size, ' ');
+	read_bytes = read(pfd_in, str.data(), size);
+
+	return (read_bytes > 0) ? str : std::string();
+}
+
 /* Open a file and put its content in a variable ('str' accept printf-like format) */
 int fopen_to_str(std::string &out, const char *str, ...)
 {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -153,6 +153,12 @@ std::string string_set_size_unit(char *str_src);
 /* Get a string containing temperature with proper unit */
 std::string string_with_temperature_unit(const double temp_celsius);
 
+/* Write a string to a pipe */
+void write_string_to_pipe(std::string str, int pfd_out);
+
+/* Read a string from a pipe */
+std::string read_string_from_pipe(int pfd_in);
+
 /* Open a file and put its content in a variable ('str' accept printf-like format) */
 int fopen_to_str(std::string &out, const char *str, ...);
 


### PR DESCRIPTION
Numerous issues were faced with OpenGL/Vulkan/OpenCL related functions (#238, #258, #264, #370, etc...). Handling SIGABRT was not enough, SIGSEV can still happen.

The idea is to refactor the OpenGL/Vulkan/OpenCL code and execute it from a child process: even if the child process crashes, the main process can continue without impacting the end-user. Example of output:
```
...
Child process 1691290 created with success for OpenCL
Finding OpenCL API version
Number of OpenCL platforms: 1
Looping into OpenCL platform 0
OpenCL platform 0: name is 'Clover'
OpenCL platform 0: version is 'OpenCL 1.1 Mesa 25.0.1-arch1.2'
OpenCL platform 0: found 1 devices
Looping into OpenCL platform 0, device 0
OpenCL platform 0, device 0: found vendor 0x1002
OpenCL platform 0, device 0: name is 'AMD Radeon RX 7800 XT (radeonsi, navi32, LLVM 19.1.7, DRM 3.61, 6.13.6-zen1-1-zen)'
OpenCL platform 0, device 0: version is 'OpenCL 1.1 Mesa 25.0.1-arch1.2'
OpenCL platform 0, device 0: vendor is AMD

Oops, something was wrong! CPU-X has received signal 11 (Segmentation fault) and has crashed.
========================= Backtrace =========================
CPU-X 5.1.3+git-r28-g62e6523e59f657311824542e247515a76e57e783-dirty (Mar 15 2025 20:26:57, Linux x86_64, GNU 14.2.1 20250207)
# 1 main.cpp:453 cpu-x() [0x454d05]
# 2 /usr/lib/libc.so.6(+0x3dcd0) [0x7b46cd6c0cd0]
# 3 libopencl.cpp:52 cpu-x() [0x4a05d9]
# 4 libopencl.cpp:172 cpu-x() [0x4a155e]
# 5 libopencl.cpp:224 cpu-x() [0x4a1b23]
# 6 libopencl.cpp:271 cpu-x() [0x4a2182]
# 7 libopencl.cpp:301 cpu-x() [0x4a25f8]
# 8 libpci.cpp:368 cpu-x() [0x49281f]
# 9 libpci.cpp:418 cpu-x() [0x492e18]
#10 libpci.cpp:491 cpu-x() [0x493318]
#11 core.cpp:430 cpu-x() [0x411dda]
#12 main.cpp:522 cpu-x() [0x455007]
#13 /usr/lib/libc.so.6(+0x27488) [0x7b46cd6aa488]
#14 /usr/lib/libc.so.6(__libc_start_main+0x8c) [0x7b46cd6aa54c]
#15 cpu-x() [0x40cc25]
======================== End Backtrace =======================

You can open a new issue here, by filling the template as requested:
https://github.com/thetumultuousunicornofdarkness/CPU-X/issues/new?template=bug_report.md

PID 1691290 terminated abnormally for OpenCL
find_devices: pci_cleanup
popen_to_str: running 'efi-readvar -v PK | grep -A1 Subject: | tail -n-1 | cut -d= -f2'
popen_to_str: running 'efi-readvar -v PK | grep -A1 Issuer:  | tail -n-1 | cut -d= -f2'
Identifying running system
...
```
So let's re-enable OpenCL support by default.