### PR TITLE
Enable building on  unsupport processer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
 	message(WARNING "'${CMAKE_SYSTEM_NAME}' system is not officially supported by CPU-X, some features will not be available.")
 endif(NOT CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
 if(NOT CPU_ISA_X86 AND NOT CPU_ISA_ARM)
-	message(FATAL_ERROR "'${CMAKE_SYSTEM_PROCESSOR}' processor is not supported by CPU-X.")
+	message(WARNING "'${CMAKE_SYSTEM_PROCESSOR}' processor is not officially supported by CPU-X, some features will not be available.")
 endif(NOT CPU_ISA_X86 AND NOT CPU_ISA_ARM)
 
 


### PR DESCRIPTION
I have previously built and used CPU-X on unsupported processors (loongarch64, mips64el, riscv64, ppc64el), but commit [3c32a91 ](https://github.com/TheTumultuousUnicornOfDarkness/CPU-X/commit/3c32a9171be740e219cf1dfb1973ff524f6099f1) has blocked this behavior. This error can be downgraded to a warning to allow support building for more platforms.