### PR TITLE
Improve the AppImage

### DIFF
--- a/.github/workflows/appimage_continuous.yml
+++ b/.github/workflows/appimage_continuous.yml
@@ -11,26 +11,20 @@ env:
 
 jobs:
   linux-appimage-continuous-build:
-    name: Linux ${{ matrix.os.arch }} (Continuous build)
-    runs-on: ${{ matrix.os.label }}
+    name: Linux ${{ matrix.arch }} (Continuous build)
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        os:
-          # x86_64 (https://github.com/actions/runner-images/tree/main/images/ubuntu)
-          - { arch: x86_64, label: ubuntu-22.04 }
-          # ARM64 (https://github.com/actions/partner-runner-images)
-          - { arch: aarch64, label: ubuntu-22.04-arm }
-
+        include:
+          - runs-on: ubuntu-latest
+            name: "AppImage build"
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            name: "AppImage build"
+            arch: aarch64
+    container: ghcr.io/pkgforge-dev/archlinux:latest
     steps:
     - uses: actions/checkout@v4
-
-    - uses: abbbi/github-actions-tune@v1
-
-    - name: Build libcpuid
-      run: bash -x ./scripts/build_libcpuid.sh "$BUILD_TYPE"
-
-    - name: Build CPU-X
-      run: bash -x ./scripts/build_cpu_x.sh "$BUILD_TYPE" "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/AppDir"
 
     - name: Package CPU-X as an AppImage
       run: |
@@ -40,7 +34,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: linux-${{ matrix.os.arch }}
+        name: linux-${{ matrix.arch }}
         path: AppImage/CPU-X-*
 
 

--- a/.github/workflows/appimage_versioned.yml
+++ b/.github/workflows/appimage_versioned.yml
@@ -15,15 +15,18 @@ env:
 
 jobs:
   linux-appimage-versioned-build:
-    name: Linux ${{ matrix.os.arch }} (Versioned build)
-    runs-on: ${{ matrix.os.label }}
+    name: Linux ${{ matrix.arch }} (Versioned build)
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        os:
-          # x86_64 (https://github.com/actions/runner-images/tree/main/images/ubuntu)
-          - { arch: x86_64, label: ubuntu-22.04 }
-          # ARM64 (https://github.com/actions/partner-runner-images)
-          - { arch: aarch64, label: ubuntu-22.04-arm }
+        include:
+          - runs-on: ubuntu-latest
+            name: "AppImage build"
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            name: "AppImage build"
+            arch: aarch64
+    container: ghcr.io/pkgforge-dev/archlinux:latest
 
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -31,8 +34,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - uses: abbbi/github-actions-tune@v1
 
     - name: Set environment variables
       id: version
@@ -46,12 +47,6 @@ jobs:
       env:
         MANUAL_TAG: ${{ inputs.version }}
 
-    - name: Build libcpuid
-      run: bash -x ./scripts/build_libcpuid.sh "$BUILD_TYPE"
-
-    - name: Build CPU-X
-      run: bash -x ./scripts/build_cpu_x.sh "$BUILD_TYPE" "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/AppDir"
-
     - name: Package CPU-X as an AppImage
       run: |
         bash -x ./scripts/build_appimage.sh "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/AppDir"
@@ -60,7 +55,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: linux-${{ matrix.os.arch }}
+        name: linux-${{ matrix.arch }}
         path: AppImage/CPU-X-*
 
 
@@ -97,6 +92,8 @@ jobs:
 
           - **AppImage (ARM64)**: CPU-X-${{ env.VERSION }}-aarch64.AppImage
           - **AppImage (x86_64)**: CPU-X-${{ env.VERSION }}-x86_64.AppImage
+
+          These AppImages are able to work everywhere, including musl and non-FHS systems, FUSE is not required at all.
 
           *Note: a Polkit Authentication agent is mandatory to start daemon from GUI.*
 

--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -133,6 +133,7 @@ runCmd "$APPDIR"/sharun -g
 # Make AppImage
 runCmd mkdir --parents --verbose "$WORKSPACE/AppImage" && runCmd cd "$_"
 runCmd wget "${WGET_ARGS[@]}" "https://github.com/pkgforge-dev/appimagetool-uruntime/releases/download/continuous/appimagetool-$ARCH.AppImage"
+runCmd wget "${WGET_ARGS[@]}" "https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-lite-$ARCH"
 runCmd chmod --verbose a+x ./appimagetool-"$ARCH".AppImage
 APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool-"$ARCH".AppImage \
-	--no-appstream -u "$UPDATE_INFORMATION" "$APPDIR"
+	--no-appstream -u "$UPDATE_INFORMATION" "$APPDIR" --runtime-file ./uruntime-appimage-squashfs-lite-"$ARCH"

--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -48,7 +48,6 @@ runCmd pacman -Syu --noconfirm \
 	glibc \
 	glibmm \
 	gtkmm3 \
-	libcpuid \
 	libglvnd \
 	libsigc++ \
 	nasm \
@@ -132,7 +131,7 @@ runCmd "$APPDIR"/sharun -g
 
 # Make AppImage
 runCmd mkdir --parents --verbose "$WORKSPACE/AppImage" && runCmd cd "$_"
-runCmd wget "${WGET_ARGS[@]}" "https://github.com/pkgforge-dev/appimagetool-uruntime/releases/download/continuous/appimagetool-$ARCH.AppImage"
+runCmd wget "${WGET_ARGS[@]}" "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$ARCH.AppImage"
 runCmd wget "${WGET_ARGS[@]}" "https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-lite-$ARCH"
 runCmd chmod --verbose a+x ./appimagetool-"$ARCH".AppImage
 APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool-"$ARCH".AppImage \

--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -20,43 +20,119 @@ if [[ $# -lt 2 ]]; then
 	exit 1
 fi
 
-WORKSPACE="$1"
-APPDIR="$2"
+# declare variables
+BUILD_TYPE="${BUILD_TYPE:-RelWithDebInfo}"
+WORKSPACE="$(realpath "$1")"
+APPDIR="$(realpath "$2")"
 WGET_ARGS=(--continue --no-verbose)
 ARCH="$(uname -m)"
 
-# Reset arguments
-set --
+runCmd mkdir -p "$APPDIR"
 
-# Download linuxdeploy and plugins
-BUNDLER="$WORKSPACE/linuxdeploy.AppImage"
-runCmd wget "${WGET_ARGS[@]}" "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${ARCH}.AppImage" --output-document="$BUNDLER" \
-	&& set -- "$@" --output appimage
-runCmd wget "${WGET_ARGS[@]}" "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh" \
-	&& set -- "$@" --plugin gtk
-runCmd wget "${WGET_ARGS[@]}" "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-ncurses/master/linuxdeploy-plugin-ncurses.sh" \
-	&& set -- "$@" --plugin ncurses
-runCmd wget "${WGET_ARGS[@]}" "https://raw.githubusercontent.com/linuxdeploy/misc-plugins/master/gettext/linuxdeploy-plugin-gettext.sh" \
-	&& set -- "$@" --plugin gettext
-#if [[ -z "$VERSION" ]]; then
-#	export LINUXDEPLOY_PLUGIN_GDB_SRC="$WORKSPACE/src"
-#	runCmd wget "${WGET_ARGS[@]}" "https://raw.githubusercontent.com/linuxdeploy/misc-plugins/master/gdb/linuxdeploy-plugin-gdb.sh" \
-#		&& set -- "$@" --plugin gdb
-#fi
-runCmd chmod --verbose a+x ./*.AppImage ./*.sh
-
-# Set useful variables for linuxdeploy
 [[ -n "$VERSION" ]] && export RELEASE="latest" || export RELEASE="continuous"
-export LDAI_UPDATE_INFORMATION="gh-releases-zsync|${GITHUB_REPOSITORY//\//|}|${RELEASE}|CPU-X-*$ARCH.AppImage.zsync"
-export LDAI_VERBOSE=1
-#export DEBUG=1
-export DISABLE_COPYRIGHT_FILES_DEPLOYMENT=1
+export UPDATE_INFORMATION="gh-releases-zsync|${GITHUB_REPOSITORY//\//|}|${RELEASE}|CPU-X-*$ARCH.AppImage.zsync"
+echo "UPDATE_INFORMATION=$UPDATE_INFORMATION"
 
-# Run linuxdeploy
-echo "LDAI_UPDATE_INFORMATION=$LDAI_UPDATE_INFORMATION"
+# Install dependencies
+runCmd pacman -Syu --noconfirm \
+	base-devel \
+	binutils \
+	cairomm \
+	cmake \
+	dconf \
+	findutils \
+	gawk \
+	gcc-libs \
+	git \
+	glib2 \
+	glibc \
+	glibmm \
+	gtkmm3 \
+	libcpuid \
+	libglvnd \
+	libsigc++ \
+	nasm \
+	ncurses \
+	ninja \
+	opencl-headers \
+	opencl-icd-loader \
+	pangomm \
+	patchelf \
+	pciutils \
+	polkit \
+	procps-ng \
+	strace \
+	valgrind \
+	vulkan-headers \
+	vulkan-icd-loader \
+	wget
+
+# install debloated packages
+if [ "$(uname -m)" = 'x86_64' ]; then
+	PKG_TYPE='x86_64.pkg.tar.zst'
+else
+	PKG_TYPE='aarch64.pkg.tar.xz'
+fi
+
+LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-$PKG_TYPE"
+runCmd wget "${WGET_ARGS[@]}" "$LIBXML_URL" -O  /tmp/libxml2.pkg.tar.zst
+runCmd pacman -U --noconfirm /tmp/libxml2.pkg.tar.zst
+
+echo "Clone libcpuid Git repository"
+git clone https://github.com/anrieff/libcpuid.git /tmp/libcpuid && (
+	cd /tmp/libcpuid
+	echo "Run CMake to build libcpuid"
+	runCmd cmake -B build \
+		-GNinja \
+		-DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DBUILD_SHARED_LIBS=OFF
+	runCmd cmake --build build
+	ninja -C build install
+)
+
+# Build CPU-X
+echo "Run CMake to build CPU-X"
+runCmd cmake -S . \
+	-B build \
+	-GNinja \
+	-DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+	-DCMAKE_INSTALL_PREFIX=/usr \
+	-DCMAKE_INSTALL_LIBEXECDIR=/usr/bin \
+	-DAPPIMAGE=1
+DESTDIR="$APPDIR" ninja -C build install
+
+# Prepare AppDir
+runCmd cp --verbose "$APPDIR/usr/share/applications/io.github.thetumultuousunicornofdarkness.cpu-x.desktop" "$APPDIR"
+runCmd cp --verbose "$APPDIR/usr/share/icons/hicolor/256x256/apps/io.github.thetumultuousunicornofdarkness.cpu-x.png" "$APPDIR"
+runCmd mv --verbose "$APPDIR"/usr "$APPDIR"/shared
+runCmd ln -s ./ "$APPDIR"/usr
+
+# Bundle deps
+runCmd wget "${WGET_ARGS[@]}" "https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
+runCmd chmod --verbose a+x ./lib4bin
+runCmd ./lib4bin -p -v -s -k \
+	--dst-dir "$APPDIR" \
+	"$APPDIR"/shared/bin/cpu-x \
+	/usr/lib/libcpuid.so* \
+	/usr/lib/libvulkan*.so* \
+	/usr/lib/libEGL.so* \
+	/usr/lib/libgirepository-*.so* \
+	/usr/lib/gvfs/* \
+	/usr/lib/gtk-*/*/immodules/*.so \
+	/usr/lib/gdk-pixbuf-*/*/loaders/*
+runCmd ./lib4bin -s --with-wrappe --dst-dir "$APPDIR"/bin "$APPDIR"/shared/bin/cpu-x-daemon
+
+runCmd cp -r "$APPDIR"/shared/share/* "$APPDIR"/share
+runCmd rm -rf "$APPDIR"/shared/share
+runCmd glib-compile-schemas "$APPDIR"/share/glib-*/schemas
+
+runCmd ln "$APPDIR"/sharun "$APPDIR"/AppRun
+runCmd "$APPDIR"/sharun -g
+
+# Make AppImage
 runCmd mkdir --parents --verbose "$WORKSPACE/AppImage" && runCmd cd "$_"
-runCmd "$BUNDLER" \
-	--appdir="$APPDIR" \
-	--desktop-file="$APPDIR/usr/share/applications/io.github.thetumultuousunicornofdarkness.cpu-x.desktop" \
-	--verbosity=1 \
-	"$@"
+runCmd wget "${WGET_ARGS[@]}" "https://github.com/pkgforge-dev/appimagetool-uruntime/releases/download/continuous/appimagetool-$ARCH.AppImage"
+runCmd chmod --verbose a+x ./appimagetool-"$ARCH".AppImage
+APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool-"$ARCH".AppImage \
+	--no-appstream -u "$UPDATE_INFORMATION" "$APPDIR"


### PR DESCRIPTION
closes #382 


Review carefully pls, relevant changes: 

* Built on Archlinux for `x86_64` and `aarch64` [using our docker images](https://github.com/pkgforge-dev/docker-archlinux)

* Reduced the size down to 25 MIB by using a libxml2 [that doesn't link to libicudata](https://github.com/pkgforge-dev/llvm-libs-debloated) repo.

* Used [sharun](https://github.com/VHSgunzo/sharun) to bundle the AppImage, making it able to work on **any linux system**, doesn't matter if it is musl or even non-FHS. 

* Used a fork of [appimagetool](https://github.com/pkgforge-dev/appimagetool-uruntime) that uses a different [runtime](https://github.com/VHSgunzo/uruntime), the advantage here being that it automatically defaults to extract and run with post cleanup if FUSE is not present on the system at all, very useful when running AppImages in containers without privileges. 

* EDIT: Also wayland works now

That runtime also provides the option to use dwarfs, which would make the AppImage likely well under 20 MIB, however I didn't use it here since it would break compatibility with AppImageLauncher.

----------------------------------------------------------

Questions/suggestions: 

* Can you build `cpu-x-daemon` to be static? (I have no idea how to make static bins xd). Right now it is using a feature of sharun, which is turning existing dynamic binaries into pseudo static bins with wrappe, but  this makes `cpu-x-daemon` 3.2 MiB while aking it properly static should be less than 1 MiB and would save that step in the CI. 

* The `-DAPPIMAGE` option isn't really needed and can be removed from the entire codebase, since it is possible to simply build with `-DCMAKE_INSTALL_LIBEXECDIR=/tmp/$RANDOM` and have the `AppRun` copy over the daemon. You saw something similar already when I made the demo repo using the archlinux binary which doesn't have that option 👀