### PR TITLE
[CI] Bump AppImage compression level

### DIFF
--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -128,6 +128,8 @@ mkdir --parents --verbose "$SRC_DIR/AppImage" && cd "$_"
 download_file "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$ARCH.AppImage"
 download_file "https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-lite-$ARCH"
 APPIMAGE_EXTRACT_AND_RUN=1 VERSION="$VERSION" "./appimagetool-$ARCH.AppImage" \
+	--mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
+	--mksquashfs-opt -b --mksquashfs-opt 1M \
 	--runtime-file "./uruntime-appimage-squashfs-lite-$ARCH" \
 	"${APPIMAGETOOL_OPTIONS[@]}" \
 	"$APPDIR"


### PR DESCRIPTION
This is something that the fork of appimagetool has different as well that I forgot 😅

The only downside is that it makes the launch time ~100ms slower

![image](https://github.com/user-attachments/assets/7bcb3a43-22d9-4e86-94e7-cfbd43609bed)

The launch time without any compression is ~560ms btw.