### PR TITLE
[CI] Add some minimum gio/module to AppImage

### DIFF
--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -110,6 +110,7 @@ download_file "https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main
 	/usr/lib/libEGL.so* \
 	/usr/lib/libgirepository-*.so* \
 	/usr/lib/gvfs/* \
+	/usr/lib/gio/modules/libdconfsettings.so \
 	/usr/lib/gtk-*/*/immodules/*.so \
 	/usr/lib/gdk-pixbuf-*/*/loaders/*
 ./lib4bin \


### PR DESCRIPTION
[noticed this comment](https://github.com/TheTumultuousUnicornOfDarkness/CPU-X/issues/388#issuecomment-2878412723)

The error is that libgio is trying to use the gio modules of the host, to avoid this issue I just added the bare minimum of gio which is `libdconfsettings`. This way `GIO_MODULE_DIR` gets set automatically by sharun and this error stops. 