### PR TITLE
add more debloated packages, fix gdk-pixbuf2

### DIFF
--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -79,8 +79,10 @@ case "$ID" in
 			*) echo "Arch '$ARCH' is not supported by $0."; exit 1;;
 		esac
 		pushd "/tmp"
-		download_file "https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-$PKG_TYPE"
-		sudo pacman -U --noconfirm "libxml2-iculess-$PKG_TYPE"
+		download_file "https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-mini-$PKG_TYPE"
+		download_file "https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/gdk-pixbuf2-mini-$PKG_TYPE"
+		download_file "https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/gtk3-mini-$PKG_TYPE"
+		sudo pacman -U --noconfirm "libxml2-mini-$PKG_TYPE" "gtk3-mini-$PKG_TYPE" "gdk-pixbuf2-mini-$PKG_TYPE"
 		popd
 		;;
 


### PR DESCRIPTION
The current continous appimages are broken because gdk-pixbuf2 was recently updated and they introduced a dependency to glycin which is not being handled by sharun. 

See: https://github.com/VHSgunzo/sharun/issues/68

While this can be fixed to use glycin, glycin is massive (20 MiB of deps) so better just use the packages that I have that remove the glycin dependency. 

gtk3-min is unrelated to this issue and just thought about adding it since it helps with size.