### PR TITLE
only include svg loaders in AppImage

### DIFF
--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -132,7 +132,7 @@ download_file "https://github.com/AppImage/appimagetool/releases/download/contin
 download_file "https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-squashfs-lite-$ARCH"
 APPIMAGE_EXTRACT_AND_RUN=1 "./appimagetool-$ARCH.AppImage" \
 	--mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
-	--mksquashfs-opt -b --mksquashfs-opt 1M \
+	--mksquashfs-opt -b --mksquashfs-opt 1M --no-appstream \
 	--runtime-file "./uruntime-appimage-squashfs-lite-$ARCH" \
 	"${APPIMAGETOOL_OPTIONS[@]}" \
 	"$APPDIR"


### PR DESCRIPTION
This reduces final size from 28 to ~25 MiB. 

The new gdkpixbuf2 that depends on glycin also ends up pulling the libjxl loader and everything that depends on it, by narrowing the glob to only the svg loader we avoid pulling all of libjxl.


Nothing should break since this restores the previous behaviour, however the CI is failing to compile CPU-X so I can't test 👀