### PR TITLE
use default cpu instead of ia64

### DIFF
--- a/src/core/bandwidth/OOC/utility-x86-64bit.asm
+++ b/src/core/bandwidth/OOC/utility-x86-64bit.asm
@@ -20,7 +20,7 @@
 ;=============================================================================
 
 bits	64
-cpu	ia64
+cpu	default
 
 ; Note:
 ; Unix ABI says integer param are put in these registers in this order:

--- a/src/core/bandwidth/routines-x86-64bit.asm
+++ b/src/core/bandwidth/routines-x86-64bit.asm
@@ -38,7 +38,7 @@
 %endif
 
 bits	64
-cpu	ia64
+cpu	default
 
 global	CopyWithMainRegisters
 global	_CopyWithMainRegisters


### PR DESCRIPTION
Recent NASM release (3.0+) enforces cpu levels more strictly, causing assembly to fail otherwise.

Fixes #401 .