### PR TITLE
[Core/bandwidth] Use 32-bit zero idiom for shorter encoding

### DIFF
--- a/src/core/bandwidth/OOC/utility-x86-64bit.asm
+++ b/src/core/bandwidth/OOC/utility-x86-64bit.asm
@@ -85,9 +85,9 @@ _get_cpuid_family1:
 	push 	rcx
 	push 	rdx
 	push 	rdi
-	xor	rax, rax
+	xor	eax, eax
 	cpuid
-	xor	rax, rax
+	xor	eax, eax
 	mov	eax, ebx
 	pop	rdi
 	pop	rdx
@@ -104,9 +104,9 @@ _get_cpuid_family2:
 	push 	rcx
 	push 	rdx
 	push 	rdi
-	xor	rax, rax
+	xor	eax, eax
 	cpuid
-	xor	rax, rax
+	xor	eax, eax
 	mov	eax, edx
 	pop	rdi
 	pop	rdx
@@ -123,9 +123,9 @@ _get_cpuid_family3:
 	push 	rcx
 	push 	rdx
 	push 	rdi
-	xor	rax, rax
+	xor	eax, eax
 	cpuid
-	xor	rax, rax
+	xor	eax, eax
 	mov	eax, ecx
 	pop	rdi
 	pop	rdx
@@ -159,7 +159,7 @@ _get_cpuid7_ebx:
 	push 	rdx
 	push 	rdi
 	mov	rax, 7
-	xor	rcx, rcx
+	xor	ecx, ecx
 	cpuid
         mov	rax, rbx
 	pop	rdi
@@ -178,7 +178,7 @@ _get_cpuid7_ecx:
 	push 	rdx
 	push 	rdi
 	mov	rax, 7
-	xor	rcx, rcx
+	xor	ecx, ecx
 	cpuid
         mov	rax, rcx
 	pop	rdi
@@ -197,7 +197,7 @@ _get_cpuid7_edx:
 	push 	rdx
 	push 	rdi
 	mov	rax, 7
-	xor	rcx, rcx
+	xor	ecx, ecx
 	cpuid
         mov	rax, rdx
 	pop	rdi

--- a/src/core/bandwidth/routines-x86-64bit.asm
+++ b/src/core/bandwidth/routines-x86-64bit.asm
@@ -1525,7 +1525,7 @@ _StackWriter:
 	push	qword 2000	; [rsp+8]
 	push	qword 1000	; [rsp]
 
-	xor	rax, rax
+	xor	eax, eax
 
 .L1:
 	; 64 transfers


### PR DESCRIPTION
Switch from `xor rax, rax` and `xor rcx, rcx` to `xor eax, eax` and `xor ecx, ecx`. The 32-bit instructions are one byte smaller while yielding the same semantics due to automatic zero-extension in 64-bit mode.