### PR TITLE
Update colors when system GTK theme changes

### DIFF
--- a/src/ui/gtk.cpp
+++ b/src/ui/gtk.cpp
@@ -630,6 +630,15 @@ void GtkData::set_signals()
 		this->settingswindow->hide();
 
 	});
+
+	/* Reload theme colors when system GTK theme changes */
+	auto gtk_settings = Gtk::Settings::get_default();
+	gtk_settings->property_gtk_theme_name().signal_changed().connect([this, gtk_settings]()
+	{
+		/* Apply new color theme */
+		this->check_theme_color();
+		this->set_colors();
+	});
 }
 
 void GtkData::bind_settings()


### PR DESCRIPTION
This is one potential fix for #415. To facilitate updating font colors during execution when the system's GTK theme is changed, (and any other aspects of the window style which go out of sync) this PR adds a callback registered to any changes on the GTK theme-name property. It then uses a somewhat dumb method of parsing the theme name to look for a "-dark" ending, and sets the app's current color scheme to match. It works flawlessly on my machine when I use the command `gsettings set org.gnome.desktop.interface gtk-theme "Adwaita(-dark)"` to change between light and dark GTK themes, but I don't know of many different GTK theme names, and a more sophisticated way of determining whether to use light or dark mode may be in order.